### PR TITLE
feat: ENABLE-7197 add continuous backup PITR tag keys

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -25,4 +25,15 @@ export interface Backup {
    * @defaultValue false
    */
   multiAccountCopy?: boolean;
+  /**
+   * Should continuous (PITR) backup be enabled for this resource.
+   * Supported for RDS/Aurora only.
+   * @defaultValue false
+   */
+  continuous?: boolean;
+  /**
+   * How many days should the continuous (PITR) backup be retained.
+   * If not set, falls back to the snapshot retention value.
+   */
+  continuousRetention?: number;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,8 @@ export const TagKeys = {
   BACKUP_SCHEDULE: 'linz.backup.schedule',
   BACKUP_MULTIREGION: 'linz.backup.multiRegionCopy',
   BACKUP_MULTIACCOUNT: 'linz.backup.multiAccountCopy',
+  BACKUP_CONTINUOUS: 'linz.backup.continuous',
+  BACKUP_CONTINUOUS_RETENTION: 'linz.backup.continuous.retention',
 
   // Logging tags
   LOGS_STREAMING_FILTER_PATTERN: 'linz.logs.streaming-filter-pattern',

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -145,6 +145,12 @@ export function applyTagsBackup(construct: IConstruct, tags: Backup): void {
   if (tags.multiAccountCopy !== undefined) {
     tag(construct, TagKeys.BACKUP_MULTIACCOUNT, String(tags.multiAccountCopy));
   }
+  if (tags.continuous !== undefined) {
+    tag(construct, TagKeys.BACKUP_CONTINUOUS, String(tags.continuous));
+  }
+  if (tags.continuousRetention !== undefined) {
+    tag(construct, TagKeys.BACKUP_CONTINUOUS_RETENTION, String(tags.continuousRetention));
+  }
 }
 
 // Streaming logs


### PR DESCRIPTION
## Summary

Adds two new tag keys to support continuous (PITR) backup configuration for RDS/Aurora resources.

## Changes

- `BACKUP_CONTINUOUS` (`linz.backup.continuous`) — opt-in flag to enable continuous/PITR backup for a resource
- `BACKUP_CONTINUOUS_RETENTION` (`linz.backup.continuous.retention`) — optional override for PITR retention period in days (falls back to snapshot retention, capped at AWS maximum of 35 days)

## Usage

```ts
applyTagsBackup(construct, {
  retention: 90,
  continuous: true,           // enables PITR
  continuousRetention: 7,     // optional: override PITR retention (default: mirrors retention, max 35)
});
