### PR TITLE
fix: allow empty filter pattern to log streaming tag ENABLE-7250

### DIFF
--- a/src/tags.ts
+++ b/src/tags.ts
@@ -82,7 +82,7 @@ export interface TagsBase {
   log_streaming?: LogStreaming;
 }
 
-// Apply a tag but skip application of tag if the value is undefined or empty
+/** Apply a tag but skip application of tag if the value is undefined or empty */
 function tag(construct: IConstruct, key: string, value: string | undefined | null): void {
   if (value == null) return;
   if (value === '') return;
@@ -149,5 +149,5 @@ export function applyTagsBackup(construct: IConstruct, tags: Backup): void {
 
 // Streaming logs
 export function applyTagsLogStreaming(construct: IConstruct, tags: LogStreaming): void {
-  tag(construct, TagKeys.LOGS_STREAMING_FILTER_PATTERN, String(tags.filter_pattern ?? ''));
+  Tags.of(construct).add(TagKeys.LOGS_STREAMING_FILTER_PATTERN, String(tags.filter_pattern ?? ''));
 }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -149,5 +149,6 @@ export function applyTagsBackup(construct: IConstruct, tags: Backup): void {
 
 // Streaming logs
 export function applyTagsLogStreaming(construct: IConstruct, tags: LogStreaming): void {
+// not using tag() function as an empty value is a legit value for this tag.
   Tags.of(construct).add(TagKeys.LOGS_STREAMING_FILTER_PATTERN, String(tags.filter_pattern ?? ''));
 }

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -149,6 +149,6 @@ export function applyTagsBackup(construct: IConstruct, tags: Backup): void {
 
 // Streaming logs
 export function applyTagsLogStreaming(construct: IConstruct, tags: LogStreaming): void {
-// not using tag() function as an empty value is a legit value for this tag.
+  // not using tag() function as an empty value is a legit value for this tag.
   Tags.of(construct).add(TagKeys.LOGS_STREAMING_FILTER_PATTERN, String(tags.filter_pattern ?? ''));
 }


### PR DESCRIPTION
allow tags like linz.logs.streaming-filter-pattern = '', which apply no filters.

as per the documentation for filter pattern's defaultValue — '' (all logs)